### PR TITLE
fix: do not run build job for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This jobs needs GitHub workflow secrets, which are not available when running Dependabot triggered workflows.